### PR TITLE
Add SecureRandom requirement to avoid NameError

### DIFF
--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -1,4 +1,5 @@
 require 'docker'
+require 'securerandom'
 require_relative 'compose_port'
 require_relative '../utils/compose_utils'
 


### PR DESCRIPTION
The model compose_container.rb uses a module that was not required
before.

I got an error while trying to create a container which was fixed after adding the `require`.
```
$ ruby test.rb
Starting containers ...
/usr/local/lib/ruby/gems/2.2.0/gems/docker-compose-api-1.0.1/lib/docker-compose/models/compose_container.rb:44:in `prepare_image': uninitialized constant ComposeContainer::SecureRandom (NameError)
	from /usr/local/lib/ruby/gems/2.2.0/gems/docker-compose-api-1.0.1/lib/docker-compose/models/compose_container.rb:127:in `start'
	from /usr/local/lib/ruby/gems/2.2.0/gems/docker-compose-api-1.0.1/lib/docker-compose/models/compose.rb:81:in `block in call_container_method'
	from /usr/local/lib/ruby/gems/2.2.0/gems/docker-compose-api-1.0.1/lib/docker-compose/models/compose.rb:80:in `each'
	from /usr/local/lib/ruby/gems/2.2.0/gems/docker-compose-api-1.0.1/lib/docker-compose/models/compose.rb:80:in `call_container_method'
	from /usr/local/lib/ruby/gems/2.2.0/gems/docker-compose-api-1.0.1/lib/docker-compose/models/compose.rb:46:in `start'
	from test.rb:42:in `<main>'
$ vim /usr/local/lib/ruby/gems/2.2.0/gems/docker-compose-api-1.0.1/lib/docker-compose/models/compose_container.rb
$ ruby test.rb
Starting containers ...
true
$
```