### PR TITLE
Bugfix: SecureRandom wasn't being required in compose_container class

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module DockerCompose
   def self.version
-    "1.0.1"
+    "1.0.2"
   end
 end


### PR DESCRIPTION
- SecureRandom wasn't being required in compose_container class, causing an error;