### PR TITLE
Add support for environment in Hash format

### DIFF
--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -15,7 +15,7 @@ class ComposeContainer
       ports: prepare_ports(hash_attributes[:ports]),
       volumes: hash_attributes[:volumes],
       command: ComposeUtils.format_command(hash_attributes[:command]),
-      environment: hash_attributes[:environment]
+      environment: prepare_environment(hash_attributes[:environment])
     }.reject{ |key, value| value.nil? }
 
     # Docker client variables
@@ -123,6 +123,14 @@ class ComposeContainer
     end
 
     ports
+  end
+
+  #
+  # Forces the environment structure to use the array format.
+  #
+  def prepare_environment(env_entries)
+    return env_entries unless env_entries.is_a?(Hash)
+    env_entries.to_a.map { |x| x.join('=') }
   end
 
   #

--- a/spec/docker-compose/docker_compose_spec.rb
+++ b/spec/docker-compose/docker_compose_spec.rb
@@ -177,6 +177,32 @@ describe DockerCompose do
     container1.stop
   end
 
+  it 'supports setting environment as array' do
+    container1 = @compose.containers.values.first
+
+    # Start container
+    container1.start
+
+    env = container1.stats['Config']['Env']
+    expect(env).to eq(%w(MYENV1=variable1))
+
+    # Stop container
+    container1.stop
+  end
+
+  it 'supports setting environment as hash' do
+    container1 = @compose.containers.values.last
+
+    # Start container
+    container1.start
+
+    env = container1.stats['Config']['Env']
+    expect(env).to eq(%w(MYENV2=variable2))
+
+    # Stop container
+    container1.stop
+  end
+
   after(:all) do
     @compose.containers.values.each do |entry|
       entry.delete

--- a/spec/docker-compose/fixtures/compose_1.yaml
+++ b/spec/docker-compose/fixtures/compose_1.yaml
@@ -9,9 +9,13 @@ busybox1:
   links:
     - busybox2
   command: ping busybox2
+  environment:
+    - MYENV1=variable1
 
 busybox2:
   image: busybox
   expose:
     - "6000"
   command: ping localhost
+  environment:
+    MYENV2: variable2

--- a/spec/docker-compose/models/compose_container_spec.rb
+++ b/spec/docker-compose/models/compose_container_spec.rb
@@ -133,4 +133,20 @@ describe ComposeContainer do
       expect{@entry.start}.to raise_error(ArgumentError)
     end
   end
+
+  context 'With environment as a hash' do
+    before(:all) do
+      @attributes = {
+        image: 'busybox:latest',
+        command: 'ping -c 3 localhost',
+        environment: { ENVIRONMENT: 'VALUE' }
+      }
+
+      @entry = ComposeContainer.new(@attributes)
+    end
+
+    it 'should prepare environment attribute correctly' do
+      expect(@entry.attributes[:environment]).to eq(%w(ENVIRONMENT=VALUE))
+    end
+  end
 end


### PR DESCRIPTION
From the [official documentation](https://docs.docker.com/compose/compose-file/#environment):

> ### environment
> Add environment variables. You can use either an array or a dictionary. 

But the dictionary format does not work with this gem.

For example, using:

```yaml
db:
  image: mariadb
  environment:
    MYSQL_ROOT_PASSWORD: myPassword
```

I get the following error:

    Docker::Error::ServerError:
    json: cannot unmarshal object into Go value of type []string