### PR TITLE
Add aliased links support

### DIFF
--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -101,7 +101,8 @@ class ComposeContainer
     links = []
 
     @dependencies.each do |dependency|
-      links << "#{dependency.stats['Id']}:#{dependency.attributes[:label]}"
+      link_name = @attributes[:links][dependency.attributes[:label]]
+      links << "#{dependency.stats['Id']}:#{link_name}"
     end
 
     links

--- a/lib/docker-compose/utils/compose_utils.rb
+++ b/lib/docker-compose/utils/compose_utils.rb
@@ -62,6 +62,8 @@ module ComposeUtils
   # Generate a pair key:hash with
   # format {service:label}
   #
+  # The label will be the conainer name if not specified.
+  #
   def self.format_links(links_array)
     links = {}
 
@@ -72,7 +74,7 @@ module ComposeUtils
 
       case parts.length
         when 1
-          links[parts[0]] = SecureRandom.hex
+          links[parts[0]] = parts[0]
 
         when 2
           links[parts[0]] = parts[1]

--- a/spec/docker-compose/docker_compose_spec.rb
+++ b/spec/docker-compose/docker_compose_spec.rb
@@ -14,7 +14,7 @@ describe DockerCompose do
   end
 
   it 'should read a YAML file correctly' do
-    expect(@compose.containers.length).to eq(2)
+    expect(@compose.containers.length).to eq(3)
   end
 
   it 'should raise error when reading an invalid YAML file' do
@@ -55,7 +55,7 @@ describe DockerCompose do
     context 'Without dependencies' do
       it 'should start/stop a single container' do
         container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values.last.attributes[:label]
+        container2 = @compose.containers.values[1].attributes[:label]
 
         # Should start Redis only, since it hasn't dependencies
         @compose.start([container2])
@@ -70,7 +70,7 @@ describe DockerCompose do
 
       it 'should start/kill a single container' do
         container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values.last.attributes[:label]
+        container2 = @compose.containers.values[1].attributes[:label]
 
         # Should start Redis only, since it hasn't dependencies
         @compose.start([container2])
@@ -87,7 +87,7 @@ describe DockerCompose do
     context 'With dependencies' do
       it 'should start/stop a single container' do
         container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values.last.attributes[:label]
+        container2 = @compose.containers.values[1].attributes[:label]
 
         # Should start Ubuntu and Redis, since Ubuntu depends on Redis
         @compose.start([container1])
@@ -106,7 +106,7 @@ describe DockerCompose do
 
       it 'should start/kill a single container' do
         container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values.last.attributes[:label]
+        container2 = @compose.containers.values[1].attributes[:label]
 
         # Should start Ubuntu and Redis, since Ubuntu depends on Redis
         @compose.start([container1])
@@ -125,7 +125,7 @@ describe DockerCompose do
 
       it 'should be able to ping a dependent container' do
         container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values.last.attributes[:label]
+        container2 = @compose.containers.values[1].attributes[:label]
 
         # Start all containers
         @compose.start
@@ -134,6 +134,20 @@ describe DockerCompose do
 
         # Ping container2 from container1
         ping_response = @compose.containers[container1].container.exec(['ping', '-c', '3', 'busybox2'])
+        expect(ping_response[2]).to eq(0) # Status 0 = OK
+      end
+
+      it 'should be able to ping a dependent aliased container' do
+        container2 = @compose.containers.values[1].attributes[:label]
+        container3 = @compose.containers.values[2].attributes[:label]
+
+        # Start all containers
+        @compose.start
+        expect(@compose.containers[container2].running?).to be true
+        expect(@compose.containers[container3].running?).to be true
+
+        # Ping container3 from container1
+        ping_response = @compose.containers[container3].container.exec(['ping', '-c', '3', 'bb2'])
         expect(ping_response[2]).to eq(0) # Status 0 = OK
       end
     end # context 'with dependencies'
@@ -191,7 +205,7 @@ describe DockerCompose do
   end
 
   it 'supports setting environment as hash' do
-    container1 = @compose.containers.values.last
+    container1 = @compose.containers.values[1]
 
     # Start container
     container1.start

--- a/spec/docker-compose/fixtures/compose_1.yaml
+++ b/spec/docker-compose/fixtures/compose_1.yaml
@@ -19,3 +19,9 @@ busybox2:
   command: ping localhost
   environment:
     MYENV2: variable2
+
+busybox3:
+  image: busybox
+  links:
+    - busybox2:bb2
+  command: ping localhost

--- a/spec/docker-compose/models/compose_container_spec.rb
+++ b/spec/docker-compose/models/compose_container_spec.rb
@@ -5,7 +5,7 @@ describe ComposeContainer do
     before(:all) do
       @attributes = {
         image: 'busybox:latest',
-        links: ['service:label'],
+        links: ['service1:label', 'service2'],
         ports: ['3000', '8000:8000', '127.0.0.1:8001:8001'],
         volumes: {'/tmp' => {}},
         command: 'ping -c 3 localhost',
@@ -17,7 +17,8 @@ describe ComposeContainer do
 
     it 'should prepare attributes correctly' do
       expect(@entry.attributes[:image]).to eq(@attributes[:image])
-      expect(@entry.attributes[:links]).to eq({'service' => 'label'})
+      expect(@entry.attributes[:links])
+        .to eq({'service1' => 'label', 'service2' => 'service2'})
       expect(@entry.attributes[:volumes]).to eq(@attributes[:volumes])
       expect(@entry.attributes[:command]).to eq(@attributes[:command].split(' '))
       expect(@entry.attributes[:environment]).to eq(@attributes[:environment])

--- a/spec/docker-compose/utils/compose_utils_spec.rb
+++ b/spec/docker-compose/utils/compose_utils_spec.rb
@@ -56,7 +56,7 @@ describe ComposeUtils do
     it 'should recognize pattern "[service]"' do
       links = ComposeUtils.format_links(['service'])
       expect(links.key?('service')).to be true
-      expect(links['service']).to_not be_nil
+      expect(links['service']).to eq('service')
     end
 
     it 'should recognize pattern "[service:label]"' do


### PR DESCRIPTION
This fixes the aliased links support.

For example:

```yaml
mydb:
  # [...]
wordpress:
  links:
    - mydb:mysql
  command: ping mysql
```

In this particular example, the *mydb* container has to be reachable from *wordpress* as *mysql* instead of *mydb*.

On the current master, the link alias seems to be completely ignored.