### PR TITLE
Add Compose#delete method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ compose.stop(['container1', 'container2', ...]) # stop a list of specific contai
 compose.kill                                    # kill all containers
 compose.kill(['container1', 'container2', ...]) # kill a list of specific containers
 
+# Deleting containers
+# (ps: container dependencies will keep running)
+compose.delete                                    # delete all containers
+compose.delete(['container1', 'container2', ...]) # delete a list of specific containers
+
 # Checking if a container is running or not
 a_container = compose.containers['a_container']
 a_container.running?

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -58,14 +58,25 @@ class Compose
   end
 
   #
-  # Stop a container
+  # Kill a container
   #
   # This method accepts an array of labels.
-  # If labels is informed, only those containers with label present in array will be stopped.
-  # Otherwise, all containers are stopped
+  # If labels is informed, only those containers with label present in array will be killed.
+  # Otherwise, all containers are killed
   #
   def kill(labels  = [])
     call_container_method(:kill, labels)
+  end
+
+  #
+  # Delete a container
+  #
+  # This method accepts an array of labels.
+  # If labels is informed, only those containers with label present in array will be deleted.
+  # Otherwise, all containers are deleted
+  #
+  def delete(labels = [])
+    call_container_method(:delete, labels)
   end
 
   private

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -164,7 +164,7 @@ class ComposeContainer
   # Stop the container
   #
   def stop
-    @container.kill unless @container.nil?
+    @container.stop unless @container.nil?
   end
 
   #

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -203,4 +203,11 @@ class ComposeContainer
   def running?
     @container.nil? ? false : self.stats['State']['Running']
   end
+
+  #
+  # Check if the container exists or not
+  #
+  def exist?
+    !@container.nil?
+  end
 end

--- a/spec/docker-compose/docker_compose_spec.rb
+++ b/spec/docker-compose/docker_compose_spec.rb
@@ -49,6 +49,20 @@ describe DockerCompose do
         expect(container.running?).to be false
       end
     end
+
+    it 'should start/delete all containers' do
+      # Start containers to test Delete
+      @compose.start
+      @compose.containers.values.each do |container|
+        expect(container.running?).to be true
+      end
+
+      # Delete containers
+      @compose.delete
+      @compose.containers.values.each do |container|
+        expect(container.exist?).to be false
+      end
+    end
   end
 
   context 'Single container' do
@@ -204,8 +218,6 @@ describe DockerCompose do
   end
 
   after(:all) do
-    @compose.containers.values.each do |entry|
-      entry.delete
-    end
+    @compose.delete
   end
 end


### PR DESCRIPTION
Add a simple `#delete` method:

```ruby
compose = DockerCompose.load('docker-compose.yml')
compose.start
compose.stop
compose.delete
```

Other tiny fixes included in this PR:
- Correct the `Compose#kill` documentation.
- `Compose#stop` calls `Container#stop` instead of `Container#kill`.