### PR TITLE
Correctly parses volumes from the compose file and set binds when creating the container

### DIFF
--- a/spec/docker-compose/docker_compose_spec.rb
+++ b/spec/docker-compose/docker_compose_spec.rb
@@ -205,6 +205,20 @@ describe DockerCompose do
     container1.stop
   end
 
+  it 'binds volumes' do
+    container1 = @compose.containers.values.first
+
+    # Start container
+    container1.start
+
+    puts container1.stats['HostConfig']['Binds'].inspect
+    volumes = container1.stats['HostConfig']['Binds']
+    expect(volumes).to match_array(['/tmp/test:/tmp:ro'])
+
+    # Stop container
+    container1.stop
+  end
+
   it 'supports setting environment as array' do
     container1 = @compose.containers.values.first
 

--- a/spec/docker-compose/fixtures/compose_1.yaml
+++ b/spec/docker-compose/fixtures/compose_1.yaml
@@ -11,6 +11,8 @@ busybox1:
   command: ping busybox2
   environment:
     - MYENV1=variable1
+  volumes:
+    - "/tmp/test:/tmp:ro"
 
 busybox2:
   image: busybox


### PR DESCRIPTION
Before this change volumes from the compose yml were send directly to the API in an array structure while it actually expects a Hash.

In order to be able to bind volumes to the host's local filesystem they should be passed through the `['HostConfig']['Binds']` attribute in the API.

* definition info:  https://docs.docker.com/compose/compose-file/#volumes-volume-driver
* docker-composed code reference: https://github.com/docker/compose/blob/2a2eb81215d6c968f01d3f355c42179c1f7cf38e/compose/config/types.py#L125-L161