### PR TITLE
Loosens the docker dependency to ~> 1.22

### DIFF
--- a/docker-compose-api.gemspec
+++ b/docker-compose-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "docker-api", "1.22.2"
+  spec.add_dependency "docker-api", "~> 1.22"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rspec", "~> 3.3"


### PR DESCRIPTION
I've been using v1.26 for the past week and everything works as expected. All tests also still pass.

Was there any reason for this strict locking? I think it will be safe to support all v1.x versions of docker-api. If not I'd lock to minor releases instead of a fixed release.