### PR TITLE
Feature: compose 'memory'

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
+--order rand
 --format documentation
 --color

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---order rand
 --format documentation
 --color

--- a/README.md
+++ b/README.md
@@ -43,10 +43,25 @@ DockerCompose.version
 # Loading a compose file
 compose = DockerCompose.load('[path to docker compose file]')
 
+# 'Load' method accepts a second argument, telling to do load or not
+# containers started previously by this compose file.
+#
+# So, loading a compose file + containers started by this compose previously
+compose = DockerCompose.load('[path to docker compose file]', true)
+
 # Accessing containers
 compose.containers                                   # access all containers
 compose.containers['container_label']                # access a container by its label (DEPRECATED)
 compose.get_containers_by(label: 'foo', name: 'bar') # Returns an array of all containers with label = 'foo' and name = bar
+
+# Containers names are generated using the pattern below:
+#  [Directory name]_[Container label]_[Sequential ID]
+#
+# So, you can access a container by its full name...
+compose.get_containers_by(name: 'myawessomedir_foobar_1')
+
+# ... or by its given name (ignores both prefix and suffix)
+compose.get_containers_by_given_name('foobar')
 
 # Starting containers (and their dependencies)
 compose.start                                    # start all containers

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -29,6 +29,16 @@ class Compose
   end
 
   #
+  # Select containers based on its given name
+  # (ignore basename)
+  #
+  def get_containers_by_given_name(given_name)
+    @containers.select { |label, container|
+      container.attributes[:name].match(/\w*_#{given_name}_\d+/)
+    }.values
+  end
+
+  #
   # Create link relations among containers
   #
   def link_containers

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -39,7 +39,7 @@ class Compose
   #
   def get_containers_by_given_name(given_name)
     @containers.select { |label, container|
-      container.attributes[:name].match(/\w*_#{given_name}_\d+/)
+      container.attributes[:name].match(/#{ComposeUtils.dir_name}_#{given_name}_\d+/)
     }.values
   end
 

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -15,6 +15,11 @@ class Compose
   # Add a new container to compose
   #
   def add_container(container)
+    # Avoid duplicated labels on compose
+    while @containers.has_key?(container.attributes[:label]) do
+      container.attributes[:label].succ!
+    end
+
     @containers[container.attributes[:label]] = container
     true
   end

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -9,7 +9,7 @@ class ComposeContainer
   def initialize(hash_attributes)
     @attributes = {
       label: hash_attributes[:label],
-      name: hash_attributes[:name].nil? ? hash_attributes[:label] : hash_attributes[:name],
+      name: ComposeUtils.generate_container_name(hash_attributes[:name], hash_attributes[:label]),
       image: ComposeUtils.format_image(hash_attributes[:image]),
       build: hash_attributes[:build],
       links: ComposeUtils.format_links(hash_attributes[:links]),

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -4,12 +4,12 @@ require_relative 'compose_port'
 require_relative '../utils/compose_utils'
 
 class ComposeContainer
-  attr_reader :attributes, :container, :dependencies
+  attr_reader :attributes, :internal_image, :container, :dependencies
 
-  def initialize(hash_attributes)
+  def initialize(hash_attributes, docker_container = nil)
     @attributes = {
       label: hash_attributes[:label],
-      name: ComposeUtils.generate_container_name(hash_attributes[:name], hash_attributes[:label]),
+      name: hash_attributes[:full_name] || ComposeUtils.generate_container_name(hash_attributes[:name], hash_attributes[:label]),
       image: ComposeUtils.format_image(hash_attributes[:image]),
       build: hash_attributes[:build],
       links: ComposeUtils.format_links(hash_attributes[:links]),
@@ -22,7 +22,7 @@ class ComposeContainer
 
     # Docker client variables
     @internal_image = nil
-    @container = nil
+    @container = docker_container
     @dependencies = []
   end
 

--- a/lib/docker-compose/utils/compose_utils.rb
+++ b/lib/docker-compose/utils/compose_utils.rb
@@ -84,6 +84,30 @@ module ComposeUtils
   end
 
   #
+  # Format ports from running container
+  #
+  def self.format_ports_from_running_container(port_entry)
+    entries = []
+    container_port = nil
+    host_ip = nil
+    host_port = nil
+
+    if port_entry.nil?
+      return entries
+    end
+
+    port_entry.each do |key, value|
+      container_port = key.gsub(/\D/, '').to_i
+      host_ip = value.first['HostIp']
+      host_port = value.first['HostPort']
+
+      entries << "#{container_port}:#{host_ip}:#{host_port}"
+    end
+
+    entries
+  end
+
+  #
   # Generate a pair key:hash with
   # format {service:label}
   #

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module DockerCompose
   def self.version
-    "1.0.5"
+    "1.1.0"
   end
 end

--- a/spec/docker-compose/docker_compose_spec.rb
+++ b/spec/docker-compose/docker_compose_spec.rb
@@ -277,7 +277,7 @@ describe DockerCompose do
     container.start
 
     container_name = container.stats['Name']
-    expect(container_name).to eq('/busybox-container')
+    expect(container_name).to match(/\/#{ComposeUtils.dir_name}_busybox-container_\d+/)
 
     # Stop container
     container.stop
@@ -298,7 +298,8 @@ describe DockerCompose do
 
   it 'should filter containers by its attributes' do
     expect(@compose.get_containers_by(label: 'busybox2')).to eq([@compose.containers['busybox2']])
-    expect(@compose.get_containers_by(name: 'busybox-container')).to eq([@compose.containers['busybox1']])
+    expect(@compose.get_containers_by(name: @compose.containers['busybox1'].attributes[:name])).to eq([@compose.containers['busybox1']])
+    expect(@compose.get_containers_by_given_name('busybox-container')).to eq([@compose.containers['busybox1']])
     expect(@compose.get_containers_by(image: 'busybox:latest')).to eq([
         @compose.containers['busybox1'],
         @compose.containers['busybox2'],

--- a/spec/docker-compose/docker_compose_spec.rb
+++ b/spec/docker-compose/docker_compose_spec.rb
@@ -1,313 +1,332 @@
 require 'spec_helper'
 
 describe DockerCompose do
-  before(:all) do
-    @compose = DockerCompose.load(File.expand_path('spec/docker-compose/fixtures/compose_1.yaml'))
-  end
+  context 'Without memory' do
+    before(:all) do
+      @compose = DockerCompose.load(File.expand_path('spec/docker-compose/fixtures/compose_1.yaml'))
+    end
 
-  it 'should be able to access gem version' do
-    expect(DockerCompose.version).to_not be_nil
-  end
+    it 'should be able to access gem version' do
+      expect(DockerCompose.version).to_not be_nil
+    end
 
-  it 'should be able to access Docker client' do
-    expect(DockerCompose.docker_client).to_not be_nil
-  end
+    it 'should be able to access Docker client' do
+      expect(DockerCompose.docker_client).to_not be_nil
+    end
 
-  it 'should read a YAML file correctly' do
-    expect(@compose.containers.length).to eq(3)
-  end
+    it 'should read a YAML file correctly' do
+      expect(@compose.containers.length).to eq(3)
+    end
 
-  it 'should raise error when reading an invalid YAML file' do
-    expect{DockerCompose.load('')}.to raise_error(ArgumentError)
-  end
+    it 'should raise error when reading an invalid YAML file' do
+      expect{DockerCompose.load('')}.to raise_error(ArgumentError)
+    end
 
-  context 'All containers' do
-    it 'should start/stop all containers' do
-      # Start containers to test Stop
-      @compose.start
-      @compose.containers.values.each do |container|
-        expect(container.running?).to be true
+    context 'All containers' do
+      it 'should start/stop all containers' do
+        # Start containers to test Stop
+        @compose.start
+        @compose.containers.values.each do |container|
+          expect(container.running?).to be true
+        end
+
+        # Stop containers
+        @compose.stop
+        @compose.containers.values.each do |container|
+          expect(container.running?).to be false
+        end
       end
 
-      # Stop containers
-      @compose.stop
-      @compose.containers.values.each do |container|
-        expect(container.running?).to be false
+      it 'should start/kill all containers' do
+        # Start containers to test Kill
+        @compose.start
+        @compose.containers.values.each do |container|
+          expect(container.running?).to be true
+        end
+
+        # Kill containers
+        @compose.kill
+        @compose.containers.values.each do |container|
+          expect(container.running?).to be false
+        end
+      end
+
+      it 'should start/delete all containers' do
+        # Start containers to test Delete
+        @compose.start
+        @compose.containers.values.each do |container|
+          expect(container.running?).to be true
+        end
+
+        # Delete containers
+        @compose.delete
+        @compose.containers.values.each do |container|
+          expect(container.exist?).to be false
+        end
       end
     end
 
-    it 'should start/kill all containers' do
-      # Start containers to test Kill
-      @compose.start
-      @compose.containers.values.each do |container|
-        expect(container.running?).to be true
+    context 'Single container' do
+      context 'Without dependencies' do
+        it 'should start/stop a single container' do
+          container1 = @compose.containers.values.first.attributes[:label]
+          container2 = @compose.containers.values[1].attributes[:label]
+
+          @compose.start([container2])
+          expect(@compose.containers[container1].running?).to be false
+          expect(@compose.containers[container2].running?).to be true
+
+          @compose.stop([container2])
+          expect(@compose.containers[container1].running?).to be false
+          expect(@compose.containers[container2].running?).to be false
+        end
+
+        it 'should start/kill a single container' do
+          container1 = @compose.containers.values.first.attributes[:label]
+          container2 = @compose.containers.values[1].attributes[:label]
+
+          @compose.start([container2])
+          expect(@compose.containers[container1].running?).to be false
+          expect(@compose.containers[container2].running?).to be true
+
+          @compose.kill([container2])
+          expect(@compose.containers[container1].running?).to be false
+          expect(@compose.containers[container2].running?).to be false
+        end
       end
 
-      # Kill containers
-      @compose.kill
-      @compose.containers.values.each do |container|
-        expect(container.running?).to be false
+      context 'With dependencies' do
+        it 'should start/stop a single container' do
+          container1 = @compose.containers.values.first.attributes[:label]
+          container2 = @compose.containers.values[1].attributes[:label]
+
+          @compose.start([container1])
+          expect(@compose.containers[container1].running?).to be true
+          expect(@compose.containers[container2].running?).to be true
+
+          @compose.stop([container1])
+          expect(@compose.containers[container1].running?).to be false
+          expect(@compose.containers[container2].running?).to be true
+
+          @compose.stop([container2])
+          expect(@compose.containers[container2].running?).to be false
+        end
+
+        it 'should start/kill a single container' do
+          container1 = @compose.containers.values.first.attributes[:label]
+          container2 = @compose.containers.values[1].attributes[:label]
+
+          @compose.start([container1])
+          expect(@compose.containers[container1].running?).to be true
+          expect(@compose.containers[container2].running?).to be true
+
+          @compose.kill([container1])
+          expect(@compose.containers[container1].running?).to be false
+          expect(@compose.containers[container2].running?).to be true
+
+          @compose.kill([container2])
+          expect(@compose.containers[container2].running?).to be false
+        end
+
+        it 'should be able to ping a dependent container' do
+          container1 = @compose.containers.values.first.attributes[:label]
+          container2 = @compose.containers.values[1].attributes[:label]
+
+          # Start all containers
+          @compose.start
+          expect(@compose.containers[container1].running?).to be true
+          expect(@compose.containers[container2].running?).to be true
+
+          # Ping container2 from container1
+          ping_response = @compose.containers[container1].container.exec(['ping', '-c', '3', 'busybox2'])
+          expect(ping_response[2]).to eq(0) # Status 0 = OK
+        end
+
+        it 'should be able to ping a dependent aliased container' do
+          container2 = @compose.containers.values[1].attributes[:label]
+          container3 = @compose.containers.values[2].attributes[:label]
+
+          # Start all containers
+          @compose.start
+          expect(@compose.containers[container2].running?).to be true
+          expect(@compose.containers[container3].running?).to be true
+
+          # Ping container3 from container1
+          ping_response = @compose.containers[container3].container.exec(['ping', '-c', '3', 'bb2'])
+          expect(ping_response[2]).to eq(0) # Status 0 = OK
+        end
       end
     end
 
-    it 'should start/delete all containers' do
-      # Start containers to test Delete
-      @compose.start
-      @compose.containers.values.each do |container|
-        expect(container.running?).to be true
-      end
+    it 'should assign ports' do
+      container = @compose.get_containers_by(label: 'busybox1').first
 
-      # Delete containers
+      # Start container
+      container.start
+
+      port_bindings = container.stats['HostConfig']['PortBindings']
+      exposed_ports = container.stats['Config']['ExposedPorts']
+
+      # Check port bindings
+      expect(port_bindings.length).to eq(3)
+      expect(port_bindings.key?('3000/tcp')).to be true
+      expect(port_bindings.key?('8000/tcp')).to be true
+      expect(port_bindings.key?('8001/tcp')).to be true
+
+      # Check exposed ports
+      expect(exposed_ports.key?('3000/tcp')).to be true
+      expect(exposed_ports.key?('8000/tcp')).to be true
+      expect(exposed_ports.key?('8001/tcp')).to be true
+
+      # Stop container
+      container.stop
+    end
+
+    it 'should link containers' do
+      container = @compose.get_containers_by(label: 'busybox1').first
+
+      # Start container
+      container.start
+
+      # Ubuntu should be linked to Redis
+      links = container.stats['HostConfig']['Links']
+      expect(links.length).to eq(1)
+
+      # Stop container
+      container.stop
+    end
+
+    it 'binds volumes' do
+      container = @compose.get_containers_by(label: 'busybox1').first
+
+      # Start container
+      container.start
+
+      volumes = container.stats['HostConfig']['Binds']
+      expect(volumes).to match_array(['/tmp/test:/tmp:ro'])
+
+      # Stop container
+      container.stop
+    end
+
+    it 'supports setting environment as array' do
+      container = @compose.get_containers_by(label: 'busybox1').first
+
+      # Start container
+      container.start
+
+      env = container.stats['Config']['Env']
+      expect(env).to eq(%w(MYENV1=variable1))
+
+      # Stop container
+      container.stop
+    end
+
+    it 'supports setting environment as hash' do
+      container = @compose.get_containers_by(label: 'busybox2').first
+
+      # Start container
+      container.start
+
+      env = container.stats['Config']['Env']
+      expect(env).to eq(%w(MYENV2=variable2))
+
+      # Stop container
+      container.stop
+    end
+
+    it 'supports setting labels as an array' do
+      container = @compose.get_containers_by(label: 'busybox1').first
+
+      # Start container
+      container.start
+
+      env = container.stats['Config']['Labels']
+      expect(env).to eq({ 'com.example.foo' => 'bar' })
+
+      # Stop container
+      container.stop
+    end
+
+    it 'supports setting labels as a hash' do
+      container = @compose.get_containers_by(label: 'busybox2').first
+
+      # Start container
+      container.start
+
+      env = container.stats['Config']['Labels']
+      expect(env).to eq({ 'com.example.foo' => 'bar' })
+
+      # Stop container
+      container.stop
+    end
+
+    it 'should assing given name to container' do
+      container = @compose.get_containers_by(label: 'busybox1').first
+
+      # Start container
+      container.start
+
+      container_name = container.stats['Name']
+      expect(container_name).to match(/\/#{ComposeUtils.dir_name}_busybox-container_\d+/)
+
+      # Stop container
+      container.stop
+    end
+
+    it 'should assing a random name to container when name is not given' do
+      container = @compose.get_containers_by(label: 'busybox2').first
+
+      # Start container
+      container.start
+
+      container_name = container.stats['Name']
+      expect(container_name).to_not be_nil
+
+      # Stop container
+      container.stop
+    end
+
+    it 'should filter containers by its attributes' do
+      expect(@compose.get_containers_by(label: 'busybox2')).to eq([@compose.containers['busybox2']])
+      expect(@compose.get_containers_by(name: @compose.containers['busybox1'].attributes[:name])).to eq([@compose.containers['busybox1']])
+      expect(@compose.get_containers_by_given_name('busybox-container')).to eq([@compose.containers['busybox1']])
+      expect(@compose.get_containers_by(image: 'busybox:latest')).to eq([
+          @compose.containers['busybox1'],
+          @compose.containers['busybox2'],
+          @compose.containers['busybox3']
+      ])
+    end
+
+    after(:all) do
       @compose.delete
-      @compose.containers.values.each do |container|
-        expect(container.exist?).to be false
-      end
     end
   end
 
-  context 'Single container' do
-    context 'Without dependencies' do
-      it 'should start/stop a single container' do
-        container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values[1].attributes[:label]
+  context 'With memory' do
+    before(:all) do
+      @compose1 = DockerCompose.load(File.expand_path('spec/docker-compose/fixtures/compose_1.yaml'), false)
+      @compose1.start
 
-        # Should start Redis only, since it hasn't dependencies
-        @compose.start([container2])
-        expect(@compose.containers[container1].running?).to be false
-        expect(@compose.containers[container2].running?).to be true
+      @compose2 = DockerCompose.load(File.expand_path('spec/docker-compose/fixtures/empty_compose.yml'), true)
+    end
 
-        # Stop Redis
-        @compose.stop([container2])
-        expect(@compose.containers[container1].running?).to be false
-        expect(@compose.containers[container2].running?).to be false
+    it 'should load all running containers from this directory' do
+      expect(@compose2.containers.length).to eq(@compose1.containers.length)
+    end
+
+    it '@compose2 should have the same containers of @compose1' do
+      docker_containers_compose1 = @compose1.containers.values.select { |c| c.container }
+      docker_containers_compose2 = @compose2.containers.values.select { |c| c.container }
+
+      # Check that both composes have the same containers (based on its names)
+      docker_containers_compose2.each_index do |index|
+        expect(docker_containers_compose2[index].attributes['Name']).to eq(docker_containers_compose1[index].attributes['Name'])
       end
+    end
 
-      it 'should start/kill a single container' do
-        container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values[1].attributes[:label]
-
-        # Should start Redis only, since it hasn't dependencies
-        @compose.start([container2])
-        expect(@compose.containers[container1].running?).to be false
-        expect(@compose.containers[container2].running?).to be true
-
-        # Stop Redis
-        @compose.kill([container2])
-        expect(@compose.containers[container1].running?).to be false
-        expect(@compose.containers[container2].running?).to be false
-      end
-    end # context 'Without dependencies'
-
-    context 'With dependencies' do
-      it 'should start/stop a single container' do
-        container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values[1].attributes[:label]
-
-        # Should start Ubuntu and Redis, since Ubuntu depends on Redis
-        @compose.start([container1])
-        expect(@compose.containers[container1].running?).to be true
-        expect(@compose.containers[container2].running?).to be true
-
-        # Stop Ubuntu (Redis keeps running)
-        @compose.stop([container1])
-        expect(@compose.containers[container1].running?).to be false
-        expect(@compose.containers[container2].running?).to be true
-
-        # Stop Redis
-        @compose.stop([container2])
-        expect(@compose.containers[container2].running?).to be false
-      end
-
-      it 'should start/kill a single container' do
-        container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values[1].attributes[:label]
-
-        # Should start Ubuntu and Redis, since Ubuntu depends on Redis
-        @compose.start([container1])
-        expect(@compose.containers[container1].running?).to be true
-        expect(@compose.containers[container2].running?).to be true
-
-        # Kill Ubuntu (Redis keeps running)
-        @compose.kill([container1])
-        expect(@compose.containers[container1].running?).to be false
-        expect(@compose.containers[container2].running?).to be true
-
-        # Kill Redis
-        @compose.kill([container2])
-        expect(@compose.containers[container2].running?).to be false
-      end
-
-      it 'should be able to ping a dependent container' do
-        container1 = @compose.containers.values.first.attributes[:label]
-        container2 = @compose.containers.values[1].attributes[:label]
-
-        # Start all containers
-        @compose.start
-        expect(@compose.containers[container1].running?).to be true
-        expect(@compose.containers[container2].running?).to be true
-
-        # Ping container2 from container1
-        ping_response = @compose.containers[container1].container.exec(['ping', '-c', '3', 'busybox2'])
-        expect(ping_response[2]).to eq(0) # Status 0 = OK
-      end
-
-      it 'should be able to ping a dependent aliased container' do
-        container2 = @compose.containers.values[1].attributes[:label]
-        container3 = @compose.containers.values[2].attributes[:label]
-
-        # Start all containers
-        @compose.start
-        expect(@compose.containers[container2].running?).to be true
-        expect(@compose.containers[container3].running?).to be true
-
-        # Ping container3 from container1
-        ping_response = @compose.containers[container3].container.exec(['ping', '-c', '3', 'bb2'])
-        expect(ping_response[2]).to eq(0) # Status 0 = OK
-      end
-    end # context 'with dependencies'
-  end # context 'Single container'
-
-  it 'should assign ports' do
-    container = @compose.get_containers_by(label: 'busybox1').first
-
-    # Start container
-    container.start
-
-    port_bindings = container.stats['HostConfig']['PortBindings']
-    exposed_ports = container.stats['Config']['ExposedPorts']
-
-    # Check port bindings
-    expect(port_bindings.length).to eq(3)
-    expect(port_bindings.key?('3000/tcp')).to be true
-    expect(port_bindings.key?('8000/tcp')).to be true
-    expect(port_bindings.key?('8001/tcp')).to be true
-
-    # Check exposed ports
-    expect(exposed_ports.key?('3000/tcp')).to be true
-    expect(exposed_ports.key?('8000/tcp')).to be true
-    expect(exposed_ports.key?('8001/tcp')).to be true
-
-    # Stop container
-    container.stop
-  end
-
-  it 'should link containers' do
-    container = @compose.get_containers_by(label: 'busybox1').first
-
-    # Start container
-    container.start
-
-    # Ubuntu should be linked to Redis
-    links = container.stats['HostConfig']['Links']
-    expect(links.length).to eq(1)
-
-    # Stop container
-    container.stop
-  end
-
-  it 'binds volumes' do
-    container = @compose.get_containers_by(label: 'busybox1').first
-
-    # Start container
-    container.start
-
-    volumes = container.stats['HostConfig']['Binds']
-    expect(volumes).to match_array(['/tmp/test:/tmp:ro'])
-
-    # Stop container
-    container.stop
-  end
-
-  it 'supports setting environment as array' do
-    container = @compose.get_containers_by(label: 'busybox1').first
-
-    # Start container
-    container.start
-
-    env = container.stats['Config']['Env']
-    expect(env).to eq(%w(MYENV1=variable1))
-
-    # Stop container
-    container.stop
-  end
-
-  it 'supports setting environment as hash' do
-    container = @compose.get_containers_by(label: 'busybox2').first
-
-    # Start container
-    container.start
-
-    env = container.stats['Config']['Env']
-    expect(env).to eq(%w(MYENV2=variable2))
-
-    # Stop container
-    container.stop
-  end
-
-  it 'supports setting labels as an array' do
-    container = @compose.get_containers_by(label: 'busybox1').first
-
-    # Start container
-    container.start
-
-    env = container.stats['Config']['Labels']
-    expect(env).to eq({ 'com.example.foo' => 'bar' })
-
-    # Stop container
-    container.stop
-  end
-
-  it 'supports setting labels as a hash' do
-    container = @compose.get_containers_by(label: 'busybox2').first
-
-    # Start container
-    container.start
-
-    env = container.stats['Config']['Labels']
-    expect(env).to eq({ 'com.example.foo' => 'bar' })
-
-    # Stop container
-    container.stop
-  end
-
-  it 'should assing given name to container' do
-    container = @compose.get_containers_by(label: 'busybox1').first
-
-    # Start container
-    container.start
-
-    container_name = container.stats['Name']
-    expect(container_name).to match(/\/#{ComposeUtils.dir_name}_busybox-container_\d+/)
-
-    # Stop container
-    container.stop
-  end
-
-  it 'should assing a random name to container when name is not given' do
-    container = @compose.get_containers_by(label: 'busybox2').first
-
-    # Start container
-    container.start
-
-    container_name = container.stats['Name']
-    expect(container_name).to_not be_nil
-
-    # Stop container
-    container.stop
-  end
-
-  it 'should filter containers by its attributes' do
-    expect(@compose.get_containers_by(label: 'busybox2')).to eq([@compose.containers['busybox2']])
-    expect(@compose.get_containers_by(name: @compose.containers['busybox1'].attributes[:name])).to eq([@compose.containers['busybox1']])
-    expect(@compose.get_containers_by_given_name('busybox-container')).to eq([@compose.containers['busybox1']])
-    expect(@compose.get_containers_by(image: 'busybox:latest')).to eq([
-        @compose.containers['busybox1'],
-        @compose.containers['busybox2'],
-        @compose.containers['busybox3']
-    ])
-  end
-
-  after(:all) do
-    @compose.delete
+    after(:all) do
+      @compose1.delete
+    end
   end
 end

--- a/spec/docker-compose/models/compose_container_spec.rb
+++ b/spec/docker-compose/models/compose_container_spec.rb
@@ -51,6 +51,10 @@ describe ComposeContainer do
       expect(port_entry.host_ip).to eq('127.0.0.1')
       expect(port_entry.host_port).to eq('8001')
     end
+
+    after(:all) do
+      @entry.delete
+    end
   end
 
   context 'From image' do
@@ -110,6 +114,11 @@ describe ComposeContainer do
       # Stop container
       @entry_autogen_name.stop
     end
+
+    after(:all) do
+      @entry.delete
+      @entry_autogen_name.delete
+    end
   end
 
   context 'From Dockerfile' do
@@ -145,6 +154,11 @@ describe ComposeContainer do
       @entry.stop
       expect(@entry.running?).to be false
     end
+
+    after(:all) do
+      Docker::Image.get(@entry.internal_image).remove(force: true)
+      @entry.delete
+    end
   end
 
   context 'Without image or Dockerfile' do
@@ -162,6 +176,10 @@ describe ComposeContainer do
     it 'should not start a container' do
       expect{@entry.start}.to raise_error(ArgumentError)
     end
+
+    after(:all) do
+      @entry.delete
+    end
   end
 
   context 'With environment as a hash' do
@@ -178,9 +196,13 @@ describe ComposeContainer do
     it 'should prepare environment attribute correctly' do
       expect(@entry.attributes[:environment]).to eq(%w(ENVIRONMENT=VALUE))
     end
+
+    after(:all) do
+      @entry.delete
+    end
   end
 
-  describe '#prepare_volumes' do
+  describe 'prepare_volumes' do
     let(:attributes) do
       { image: 'busybox:latest' }
     end

--- a/spec/docker-compose/models/compose_container_spec.rb
+++ b/spec/docker-compose/models/compose_container_spec.rb
@@ -20,7 +20,7 @@ describe ComposeContainer do
 
     it 'should prepare attributes correctly' do
       expect(@entry.attributes[:image]).to eq(@attributes[:image])
-      expect(@entry.attributes[:name]).to eq(@attributes[:name])
+      expect(@entry.attributes[:name]).to match(/#{ComposeUtils.dir_name}_#{@attributes[:name]}_\d+/)
       expect(@entry.attributes[:links])
         .to eq({'service1' => 'label', 'service2' => 'service2'})
       expect(@entry.attributes[:volumes]).to eq(@attributes[:volumes])
@@ -95,7 +95,7 @@ describe ComposeContainer do
       #Start container
       @entry.start
 
-      expect(@entry.stats['Name']).to eq("/#{@attributes[:name]}")
+      expect(@entry.stats['Name']).to match(/#{ComposeUtils.dir_name}_#{@attributes[:name]}_\d+/)
 
       # Stop container
       @entry.stop
@@ -105,7 +105,7 @@ describe ComposeContainer do
       #Start container
       @entry_autogen_name.start
 
-      expect(@entry_autogen_name.stats['Name']).to eq("/#{@entry_autogen_name.attributes[:label]}")
+      expect(@entry_autogen_name.stats['Name']).to match(/#{ComposeUtils.dir_name}_#{@entry_autogen_name.attributes[:label]}_\d+/)
 
       # Stop container
       @entry_autogen_name.stop
@@ -115,6 +115,7 @@ describe ComposeContainer do
   context 'From Dockerfile' do
     before(:all) do
       attributes = {
+        label: 'foobar',
         build: File.expand_path('spec/docker-compose/fixtures/'),
         links: ['links:links'],
         volumes: ['/tmp']

--- a/spec/docker-compose/models/compose_spec.rb
+++ b/spec/docker-compose/models/compose_spec.rb
@@ -72,5 +72,18 @@ describe Compose do
         expect(container3.dependencies.empty?).to be true
       end
     end
+
+    it 'should increment label when already exists' do
+      @compose = Compose.new
+
+      # Add the same container twice
+      @compose.add_container(ComposeContainer.new(@attributes_container1))
+      @compose.add_container(ComposeContainer.new(@attributes_container1))
+
+      label_first_container  = @compose.containers.keys[0]
+      label_second_container = @compose.containers.keys[1]
+
+      expect(label_first_container).to_not eq(label_second_container)
+    end
   end
 end

--- a/spec/docker-compose/utils/compose_utils_spec.rb
+++ b/spec/docker-compose/utils/compose_utils_spec.rb
@@ -52,6 +52,26 @@ describe ComposeUtils do
     end
   end
 
+  context 'Format ports from running containers' do
+    before(:all) do
+      @hash_attr = {
+        '8000/tcp' => [{
+          'HostIp' => '0.0.0.0',
+          'HostPort' => '4444'
+        }]
+      }
+      @expected_format = ['8000:0.0.0.0:4444']
+    end
+
+    it 'should format ports correctly' do
+      expect(ComposeUtils.format_ports_from_running_container(@hash_attr)).to eq(@expected_format)
+    end
+
+    it 'should return an empty array when ports are nil' do
+      expect(ComposeUtils.format_ports_from_running_container(nil)).to eq([])
+    end
+  end
+
   context 'Format links' do
     it 'should recognize pattern "[service]"' do
       links = ComposeUtils.format_links(['service'])

--- a/spec/docker-compose/utils/compose_utils_spec.rb
+++ b/spec/docker-compose/utils/compose_utils_spec.rb
@@ -65,4 +65,21 @@ describe ComposeUtils do
       expect(links['service']).to eq('label')
     end
   end
+
+  context 'Generate container name' do
+    before(:all) do
+      @name = 'foo'
+      @label = 'bar'
+    end
+
+    it 'should generate name with given name' do
+      name = ComposeUtils.generate_container_name(@name, @label)
+      expect(name).to match(/#{ComposeUtils.dir_name}_#{@name}_\d+/)
+    end
+
+    it 'should generate name with label' do
+      name = ComposeUtils.generate_container_name(nil, @label)
+      expect(name).to match(/#{ComposeUtils.dir_name}_#{@label}_\d+/)
+    end
+  end
 end


### PR DESCRIPTION
This PR provides the ability to compose recognize containers started by it previously and reload them in a different context.

This is done analyzing the containers name, searching for those who has the same pattern of current compose.

This feature is optional and must be enabled explicitly on compose load method (instructions provided on README file).