### PR TITLE
Adds lib/docker-compose-api.rb to automatically require 'docker-compose'

### DIFF
--- a/lib/docker-compose-api.rb
+++ b/lib/docker-compose-api.rb
@@ -1,0 +1,1 @@
+require 'docker-compose'


### PR DESCRIPTION
This avoids the need for `require: 'docker-compose'` in the Gemfile.