### PR TITLE
Add Basic Support for V2 Docker-Compose Configs

### DIFF
--- a/lib/docker-compose.rb
+++ b/lib/docker-compose.rb
@@ -1,6 +1,7 @@
 require_relative 'docker-compose/models/compose'
 require_relative 'docker-compose/models/compose_container'
 require_relative 'version'
+require_relative 'docker_compose_config'
 
 require 'yaml'
 require 'docker'
@@ -22,10 +23,13 @@ module DockerCompose
       raise ArgumentError, 'Compose file doesn\'t exists'
     end
 
+    # Parse the docker-compose config
+    config = DockerComposeConfig.new(filepath)
+
     compose = Compose.new
 
     # Load new containers
-    load_containers_from_file(filepath, compose)
+    load_containers_from_config(config, compose)
 
     # Load running containers
     if do_load_running_containers
@@ -38,11 +42,11 @@ module DockerCompose
     compose
   end
 
-  def self.load_containers_from_file(filepath, compose)
-    _compose_entries = YAML.load_file(filepath)
+  def self.load_containers_from_config(config, compose)
+    compose_entries = config.services
 
-    if _compose_entries
-      _compose_entries.each do |entry|
+    if compose_entries
+      compose_entries.each do |entry|
         compose.add_container(create_container(entry))
       end
     end
@@ -91,7 +95,7 @@ module DockerCompose
     ComposeContainer.new(container_args, container)
   end
 
-  private_class_method :load_containers_from_file,
+  private_class_method :load_containers_from_config,
                        :create_container,
                        :load_running_containers,
                        :load_running_container

--- a/lib/docker_compose_config.rb
+++ b/lib/docker_compose_config.rb
@@ -1,0 +1,39 @@
+# Support multiple versions for docker-compose configs.
+class DockerComposeConfig
+  attr_reader :version, :services, :volumes, :networks
+
+  def initialize(filepath)
+    parse_docker_compose_config(filepath)
+  end
+
+  # Parse the docker-compose config
+  def parse_docker_compose_config(filepath)
+    config = YAML.load_file(filepath)
+
+    unless config
+      STDERR.puts "Empty YAML file: #{filepath}"
+      config = YAML.load('{}')
+    end
+
+    case (config['version'])
+    when 2,'2'
+      parse_version_2(config)
+    else
+      parse_version_1(config)
+    end
+  end
+
+  def parse_version_2(config)
+    @version = 2
+    @services = config['services']
+    @volumes = config['volumes']
+    @networks = config['networks']
+  end
+
+  def parse_version_1(config)
+    @version = 1
+    @services = config
+    @volumes = nil
+    @networks = nil
+  end
+end

--- a/spec/docker-compose/docker_compose_config_spec.rb
+++ b/spec/docker-compose/docker_compose_config_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'a docker config' do
+  it 'should have the correct version info' do
+    expect(config.version).to eq config_version
+  end
+
+  it 'should read a YAML file correctly' do
+    expect(config.services.length).to eq(num_services)
+  end
+end
+
+describe DockerComposeConfig do
+  context 'Handles version 2 config' do
+    config_file = File.expand_path('spec/docker-compose/fixtures/compose_2.yaml')
+
+    it_behaves_like 'a docker config' do
+      let(:config_version) { 2 }
+      let(:num_services) { 3 }
+      let(:config) { DockerComposeConfig.new(config_file) }
+    end
+  end
+
+  context 'Handles version 1 config' do
+    config_file = File.expand_path('spec/docker-compose/fixtures/compose_1.yaml')
+
+    it_behaves_like 'a docker config' do
+      let(:config_version) { 1 }
+      let(:num_services) { 3 }
+      let(:config) { DockerComposeConfig.new(config_file) }
+    end
+  end
+
+  context 'Handles empty files' do
+    config_file = File.expand_path('spec/docker-compose/fixtures/empty_compose.yml')
+
+    it_behaves_like 'a docker config' do
+      let(:config_version) { 1 }
+      let(:num_services) { 0 }
+      let(:config) { DockerComposeConfig.new(config_file) }
+    end
+  end
+end

--- a/spec/docker-compose/fixtures/compose_2.yaml
+++ b/spec/docker-compose/fixtures/compose_2.yaml
@@ -1,0 +1,37 @@
+version: 2
+
+services:
+  busybox1:
+    image: busybox
+    container_name: busybox-container
+    ports:
+      - "3000"
+      - "8000:8000"
+      - "127.0.0.1:8001:8001"
+    expose:
+      - "5000"
+    links:
+      - busybox2
+    command: ping busybox2
+    environment:
+      - MYENV1=variable1
+    volumes:
+      - "/tmp/test:/tmp:ro"
+    labels:
+      - com.example.foo=bar
+
+  busybox2:
+    image: busybox
+    expose:
+      - "6000"
+    command: ping localhost
+    environment:
+      MYENV2: variable2
+    labels:
+      com.example.foo: bar
+
+  busybox3:
+    image: busybox
+    links:
+      - busybox2:bb2
+    command: ping localhost


### PR DESCRIPTION
This commit adds support for V2 docker-compose configs. It does not add
any functionality included in the new style of config. Specifically, it
does not add functionality for the new Volume or Network entries. It
also doesn't handle the fact that some keys have had their positions in
the config tree moved.