### PR TITLE
Deleting deleted containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.byebug_history

--- a/docker-compose-api.gemspec
+++ b/docker-compose-api.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "simplecov", "~> 0.10"
+  spec.add_development_dependency "byebug", "~> 8.2"
 end

--- a/lib/docker-compose.rb
+++ b/lib/docker-compose.rb
@@ -89,7 +89,9 @@ module DockerCompose
       volumes:     info['Config']['Volumes'],
       command:     info['Config']['Cmd'].join(' '),
       environment: info['Config']['Env'],
-      labels:      info['Config']['Labels']
+      labels:      info['Config']['Labels'],
+
+      loaded_from_environment: true
     }
 
     ComposeContainer.new(container_args, container)

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -50,7 +50,7 @@ class Compose
     @containers.each_value do |container|
       links = container.attributes[:links]
 
-      next if links.nil?
+      next if (container.loaded_from_environment? or links.nil?)
 
       links.each do |service, label|
         dependency_container = @containers[service]
@@ -101,6 +101,7 @@ class Compose
   #
   def delete(labels = [])
     call_container_method(:delete, labels)
+    delete_containers_entries(labels)
   end
 
   private
@@ -114,6 +115,16 @@ class Compose
 
     containers.values.each do |entry|
       entry.send(method)
+    end
+
+    true
+  end
+
+  def delete_containers_entries(labels = [])
+    labels = @containers.keys if labels.empty?
+
+    labels.each do |label|
+      @containers.delete(label)
     end
 
     true

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -9,6 +9,7 @@ class ComposeContainer
   def initialize(hash_attributes, docker_container = nil)
     @attributes = {
       label: hash_attributes[:label],
+      loaded_from_environment: hash_attributes[:loaded_from_environment] || false,
       name: hash_attributes[:full_name] || ComposeUtils.generate_container_name(hash_attributes[:name], hash_attributes[:label]),
       image: ComposeUtils.format_image(hash_attributes[:image]),
       build: hash_attributes[:build],
@@ -24,6 +25,14 @@ class ComposeContainer
     @internal_image = nil
     @container = docker_container
     @dependencies = []
+  end
+
+  #
+  # Returns true if is a container loaded from
+  # environment instead compose file (i.e. a running container)
+  #
+  def loaded_from_environment?
+    attributes[:loaded_from_environment]
   end
 
   private

--- a/lib/docker_compose_config.rb
+++ b/lib/docker_compose_config.rb
@@ -11,7 +11,6 @@ class DockerComposeConfig
     config = YAML.load_file(filepath)
 
     unless config
-      STDERR.puts "Empty YAML file: #{filepath}"
       config = YAML.load('{}')
     end
 

--- a/spec/docker-compose/models/compose_container_spec.rb
+++ b/spec/docker-compose/models/compose_container_spec.rb
@@ -122,15 +122,20 @@ describe ComposeContainer do
   end
 
   context 'From Dockerfile' do
-    before(:all) do
-      attributes = {
+    before(:all) {
+      @attributes = {
         label: 'foobar',
         build: File.expand_path('spec/docker-compose/fixtures/'),
         links: ['links:links'],
         volumes: ['/tmp']
       }
 
-      @entry = ComposeContainer.new(attributes)
+      @entry = ComposeContainer.new(@attributes)
+    }
+
+    after(:all) do
+      Docker::Image.get(@entry.internal_image).remove(force: true)
+      @entry.delete
     end
 
     it 'should start/stop a container' do
@@ -153,11 +158,6 @@ describe ComposeContainer do
       # Stop container
       @entry.stop
       expect(@entry.running?).to be false
-    end
-
-    after(:all) do
-      Docker::Image.get(@entry.internal_image).remove(force: true)
-      @entry.delete
     end
   end
 

--- a/spec/docker-compose/models/compose_spec.rb
+++ b/spec/docker-compose/models/compose_spec.rb
@@ -31,6 +31,14 @@ describe Compose do
         image: 'busybox:latest',
         command: 'ping -c 3 localhost'
       }
+
+      @attributes_container_from_environment = {
+        label: 'container_from_environment',
+        image: 'busybox:latest',
+        links: ['container3'],
+        command: 'ping -c 3 localhost',
+        loaded_from_environment: true
+      }
     end
 
     context 'Without dependencies' do
@@ -57,11 +65,12 @@ describe Compose do
         @compose = Compose.new
         @compose.add_container(ComposeContainer.new(@attributes_container2))
         @compose.add_container(ComposeContainer.new(@attributes_container3))
+        @compose.add_container(ComposeContainer.new(@attributes_container_from_environment))
         @compose.link_containers
       end
 
       it 'should have 2 containers' do
-        expect(@compose.containers.length).to eq(2)
+        expect(@compose.containers.length).to eq(3)
       end
 
       it 'container2 should depend on container3' do
@@ -70,6 +79,11 @@ describe Compose do
 
         expect(container2.dependencies.include?(container3)).to be true
         expect(container3.dependencies.empty?).to be true
+      end
+
+      it 'container loaded from environment should not have dependencies' do
+        container_from_environment = @compose.containers[@attributes_container_from_environment[:label]]
+        expect(container_from_environment.dependencies.empty?).to be true
       end
     end
 

--- a/spec/docker-compose/utils/compose_utils_spec.rb
+++ b/spec/docker-compose/utils/compose_utils_spec.rb
@@ -53,22 +53,35 @@ describe ComposeUtils do
   end
 
   context 'Format ports from running containers' do
-    before(:all) do
-      @hash_attr = {
-        '8000/tcp' => [{
-          'HostIp' => '0.0.0.0',
-          'HostPort' => '4444'
-        }]
+    context 'filled port attributes' do
+      let(:hash_attr) {
+        {
+          '8000/tcp' => [{
+            'HostIp' => '0.0.0.0',
+            'HostPort' => '4444'
+          }]
+        }
       }
-      @expected_format = ['8000:0.0.0.0:4444']
+      let(:expected_format) { ['8000:0.0.0.0:4444'] }
+
+      it 'should format ports correctly' do
+        expect(ComposeUtils.format_ports_from_running_container(hash_attr)).to eq(expected_format)
+      end
     end
 
-    it 'should format ports correctly' do
-      expect(ComposeUtils.format_ports_from_running_container(@hash_attr)).to eq(@expected_format)
+    context 'port without value' do
+      let(:hash_attr) { {'8000/tcp' => nil} }
+      let(:expected_format) { ['8000::'] }
+
+      it 'should format ports correctly' do
+        expect(ComposeUtils.format_ports_from_running_container(hash_attr)).to eq(expected_format)
+      end
     end
 
-    it 'should return an empty array when ports are nil' do
-      expect(ComposeUtils.format_ports_from_running_container(nil)).to eq([])
+    context 'nil port' do
+      it 'should return an empty array when ports are nil' do
+        expect(ComposeUtils.format_ports_from_running_container(nil)).to eq([])
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+require 'byebug'
 require 'simplecov'
 require 'codeclimate-test-reporter'
 


### PR DESCRIPTION
After deleted, containers should no longer exist in compose. Otherwise,
an error is raised when trying to restart them.

This fix deletes container entries from compose after deleted.

To reload the deleted entries, compose file should be reloaded,
following original behavior of docker compose.