### PR TITLE
container_name enhance

### DIFF
--- a/lib/docker-compose.rb
+++ b/lib/docker-compose.rb
@@ -55,7 +55,7 @@ module DockerCompose
   def self.load_running_containers(compose)
     Docker::Container
       .all(all: true)
-      .select {|c| c.info['Names'].last.match(/\A\/#{ComposeUtils.dir_name}\w*/) }
+      .select {|c| c.info['Labels']['com.docker.compose.project'] == ComposeUtils.dir_name }
       .each do |container|
         compose.add_container(load_running_container(container))
     end
@@ -64,7 +64,7 @@ module DockerCompose
   def self.create_container(attributes)
     ComposeContainer.new({
       label: attributes[0],
-      name: attributes[1]['container_name'],
+      full_name: attributes[1]['container_name'],
       image: attributes[1]['image'],
       build: attributes[1]['build'],
       links: attributes[1]['links'],

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -19,7 +19,9 @@ class ComposeContainer
       command: ComposeUtils.format_command(hash_attributes[:command]),
       environment: prepare_environment(hash_attributes[:environment]),
       labels: prepare_labels(hash_attributes[:labels])
-    }.reject{ |key, value| value.nil? }
+    }.reject { |key, value| value.nil? }
+
+    prepare_compose_labels
 
     # Docker client variables
     @internal_image = nil
@@ -180,6 +182,17 @@ class ComposeContainer
   def prepare_labels(labels)
     return labels unless labels.is_a?(Array)
     Hash[labels.map { |label| label.split('=') }]
+  end
+
+  #
+  # Adds internal docker-compose labels
+  #
+  def prepare_compose_labels
+    @attributes[:labels] = {} unless @attributes[:labels].is_a?(Hash)
+
+    @attributes[:labels]['com.docker.compose.project'] = ComposeUtils.dir_name
+    @attributes[:labels]['com.docker.compose.service'] = @attributes[:label]
+    @attributes[:labels]['com.docker.compose.oneoff'] = 'False'
   end
 
   #

--- a/spec/docker-compose/docker_compose_spec.rb
+++ b/spec/docker-compose/docker_compose_spec.rb
@@ -218,7 +218,7 @@ describe DockerCompose do
       container.start
 
       env = container.stats['Config']['Env']
-      expect(env).to eq(%w(MYENV1=variable1))
+      expect(env).to include('MYENV1=variable1')
 
       # Stop container
       container.stop
@@ -231,7 +231,7 @@ describe DockerCompose do
       container.start
 
       env = container.stats['Config']['Env']
-      expect(env).to eq(%w(MYENV2=variable2))
+      expect(env).to include('MYENV2=variable2')
 
       # Stop container
       container.stop
@@ -244,7 +244,7 @@ describe DockerCompose do
       container.start
 
       env = container.stats['Config']['Labels']
-      expect(env).to eq({ 'com.example.foo' => 'bar' })
+      expect(env['com.example.foo']).to eq('bar')
 
       # Stop container
       container.stop
@@ -257,20 +257,33 @@ describe DockerCompose do
       container.start
 
       env = container.stats['Config']['Labels']
-      expect(env).to eq({ 'com.example.foo' => 'bar' })
+      expect(env['com.example.foo']).to eq('bar')
 
       # Stop container
       container.stop
     end
 
     it 'should assing given name to container' do
+      container = @compose.get_containers_by(label: 'busybox2').first
+
+      # Start container
+      container.start
+
+      container_name = container.stats['Name']
+      expect(container_name).to match(/\/#{ComposeUtils.dir_name}_busybox2_\d+/)
+
+      # Stop container
+      container.stop
+    end
+
+    it 'should assing given container_name to container' do
       container = @compose.get_containers_by(label: 'busybox1').first
 
       # Start container
       container.start
 
       container_name = container.stats['Name']
-      expect(container_name).to match(/\/#{ComposeUtils.dir_name}_busybox-container_\d+/)
+      expect(container_name).to eq('/busybox-container')
 
       # Stop container
       container.stop
@@ -292,7 +305,8 @@ describe DockerCompose do
     it 'should filter containers by its attributes' do
       expect(@compose.get_containers_by(label: 'busybox2')).to eq([@compose.containers['busybox2']])
       expect(@compose.get_containers_by(name: @compose.containers['busybox1'].attributes[:name])).to eq([@compose.containers['busybox1']])
-      expect(@compose.get_containers_by_given_name('busybox-container')).to eq([@compose.containers['busybox1']])
+      expect(@compose.get_containers_by_given_name('busybox2')).to eq([@compose.containers['busybox2']])
+      expect(@compose.get_containers_by(name: 'busybox-container')).to eq([@compose.containers['busybox1']])
       expect(@compose.get_containers_by(image: 'busybox:latest')).to eq([
           @compose.containers['busybox1'],
           @compose.containers['busybox2'],


### PR DESCRIPTION
- Added compose internal labels to identify project containers propertly (not relying on container names)
- Same behaviour with container_name as in original docker-compose
