### PR TITLE
Support dockerfile key in compose feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 .byebug_history
+.idea

--- a/lib/docker-compose.rb
+++ b/lib/docker-compose.rb
@@ -67,6 +67,7 @@ module DockerCompose
       name: attributes[1]['container_name'],
       image: attributes[1]['image'],
       build: attributes[1]['build'],
+      dockerfile: attributes[1]['dockerfile'],
       links: attributes[1]['links'],
       ports: attributes[1]['ports'],
       volumes: attributes[1]['volumes'],
@@ -87,7 +88,7 @@ module DockerCompose
       links:       info['HostConfig']['Links'],
       ports:       ComposeUtils.format_ports_from_running_container(info['NetworkSettings']['Ports']),
       volumes:     info['Config']['Volumes'],
-      command:     info['Config']['Cmd'].join(' '),
+      command:     (info['Config'].fetch('Cmd') || []).join(' '),
       environment: info['Config']['Env'],
       labels:      info['Config']['Labels'],
 

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -107,6 +107,7 @@ class Compose
   private
 
   def call_container_method(method, labels = [])
+
     labels = @containers.keys if labels.empty?
 
     containers = @containers.select { |key, value|

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -110,7 +110,7 @@ class Compose
 
     labels = @containers.keys if labels.empty?
 
-    containers = @containers.select { |key, value|
+    containers = @containers.keys.select { |key|
       labels.include?(key)
     }
 

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -13,6 +13,7 @@ class ComposeContainer
       name: hash_attributes[:full_name] || ComposeUtils.generate_container_name(hash_attributes[:name], hash_attributes[:label]),
       image: ComposeUtils.format_image(hash_attributes[:image]),
       build: hash_attributes[:build],
+      dockerfile: hash_attributes[:dockerfile],
       links: ComposeUtils.format_links(hash_attributes[:links]),
       ports: prepare_ports(hash_attributes[:ports]),
       volumes: hash_attributes[:volumes],
@@ -54,7 +55,10 @@ class ComposeContainer
       end
     elsif @attributes.key?(:build)
       @internal_image = SecureRandom.hex # Random name for image
-      Docker::Image.build_from_dir(@attributes[:build], {t: @internal_image})
+      opts = {t: @internal_image}
+      opts[:dockerfile] = @attributes[:dockerfile] if(@attributes[:dockerfile])
+
+      Docker::Image.build_from_dir(@attributes[:build], opts)
     end
   end
 


### PR DESCRIPTION
Fixes bug when building the command via join but No Cmd present in hash - cannot join on nil

Adds support for non standard dockerfile names in a compose file for example

```yaml
techno:
  build: .
  dockerfile: Dockerfile-techno
```

Would previously fail as would attempt to to build via Dockerfile, now correctly uses Dockerfile-techno