### PR TITLE
Support dockerfile key and env vars in compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 .byebug_history
+.idea

--- a/lib/docker-compose.rb
+++ b/lib/docker-compose.rb
@@ -63,9 +63,8 @@ module DockerCompose
   end
 
   def self.create_container(attributes)
-    service_config = attributes[1]
 
-    ComposeUtils.format_service_config(service_config)
+    service_config = ComposeUtils.parse_env_variables(attributes[1])
 
     ComposeContainer.new({
                              label: attributes[0],

--- a/lib/docker-compose.rb
+++ b/lib/docker-compose.rb
@@ -67,6 +67,7 @@ module DockerCompose
       name: attributes[1]['container_name'],
       image: attributes[1]['image'],
       build: attributes[1]['build'],
+      dockerfile: attributes[1]['dockerfile'],
       links: attributes[1]['links'],
       ports: attributes[1]['ports'],
       volumes: attributes[1]['volumes'],
@@ -87,7 +88,7 @@ module DockerCompose
       links:       info['HostConfig']['Links'],
       ports:       ComposeUtils.format_ports_from_running_container(info['NetworkSettings']['Ports']),
       volumes:     info['Config']['Volumes'],
-      command:     info['Config']['Cmd'].join(' '),
+      command:     (info['Config'].fetch('Cmd') || []).join(' '),
       environment: info['Config']['Env'],
       labels:      info['Config']['Labels'],
 

--- a/lib/docker-compose/exceptions.rb
+++ b/lib/docker-compose/exceptions.rb
@@ -1,0 +1,9 @@
+module DockerCompose
+
+  module Exceptions
+
+    class BadSubstitution < StandardError; end
+
+  end
+end
+

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -107,6 +107,7 @@ class Compose
   private
 
   def call_container_method(method, labels = [])
+
     labels = @containers.keys if labels.empty?
 
     containers = @containers.select { |key, value|

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -110,13 +110,7 @@ class Compose
 
     labels = @containers.keys if labels.empty?
 
-    containers = @containers.keys.select { |key|
-      labels.include?(key)
-    }
-
-    containers.values.each do |entry|
-      entry.send(method)
-    end
+    @containers.each { |key, entry| entry.send(method) if labels.include?(key)  }
 
     true
   end

--- a/lib/docker-compose/models/compose.rb
+++ b/lib/docker-compose/models/compose.rb
@@ -110,7 +110,7 @@ class Compose
 
     labels = @containers.keys if labels.empty?
 
-    containers = @containers.select { |key, value|
+    containers = @containers.keys.select { |key|
       labels.include?(key)
     }
 

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -13,6 +13,7 @@ class ComposeContainer
       name: hash_attributes[:full_name] || ComposeUtils.generate_container_name(hash_attributes[:name], hash_attributes[:label]),
       image: ComposeUtils.format_image(hash_attributes[:image]),
       build: hash_attributes[:build],
+      dockerfile: hash_attributes[:dockerfile],
       links: ComposeUtils.format_links(hash_attributes[:links]),
       ports: prepare_ports(hash_attributes[:ports]),
       volumes: hash_attributes[:volumes],
@@ -54,7 +55,10 @@ class ComposeContainer
       end
     elsif @attributes.key?(:build)
       @internal_image = SecureRandom.hex # Random name for image
-      Docker::Image.build_from_dir(@attributes[:build], {t: @internal_image})
+      opts = {t: @internal_image}
+      opts[:dockerfile] = @attributes[:dockerfile] if(@attributes[:dockerfile])
+
+      Docker::Image.build_from_dir(@attributes[:build], opts)
     end
   end
 

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -22,7 +22,6 @@ class ComposeContainer
       labels: prepare_labels(hash_attributes[:labels])
     }.reject{ |key, value| value.nil? }
 
-
     # Docker client variables
     @internal_image = nil
     @container = docker_container

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -22,6 +22,7 @@ class ComposeContainer
       labels: prepare_labels(hash_attributes[:labels])
     }.reject{ |key, value| value.nil? }
 
+
     # Docker client variables
     @internal_image = nil
     @container = docker_container
@@ -93,6 +94,7 @@ class ComposeContainer
     query_params = { 'name' => @attributes[:name] }
 
     params = container_config.merge(query_params)
+
     @container = Docker::Container.create(params)
   end
 

--- a/lib/docker-compose/models/compose_container.rb
+++ b/lib/docker-compose/models/compose_container.rb
@@ -28,6 +28,10 @@ class ComposeContainer
     @dependencies = []
   end
 
+  def name
+    @attributes[:name] || ""
+  end
+
   #
   # Returns true if is a container loaded from
   # environment instead compose file (i.e. a running container)

--- a/spec/docker-compose/docker_compose_env_var_spec.rb
+++ b/spec/docker-compose/docker_compose_env_var_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe DockerCompose do
+
+  context 'Error Situations' do
+
+    it 'should raise an exception when no such env var for a placeholder' do
+      expect {
+        @compose = DockerCompose.load(File.expand_path('spec/docker-compose/fixtures/compose_env_vars.yaml'))
+      }.to raise_error DockerCompose::Exceptions::BadSubstitution
+
+    end
+  end
+
+  context 'Compose File Contains Env Vars' do
+
+    before :all do
+      ENV['DOCKER_PORT_1'] = '3000'
+      ENV['DOCKER_MYENV1_VALUE'] =  'MYENV1_VALUE'
+      ENV['DOCKER_HOST_DATA_DIR'] = '/tmp/test'
+      ENV['DOCKER_IMAGE'] = 'alpine'
+      ENV['DOCKER_PING_TARGET'] = 'localhost'
+    end
+
+    context 'Tools to perform Env Var Substitution' do
+
+      let(:expected) {
+        ['3000', 'MYENV1_VALUE', '/tmp/test','alpine','localhost']
+      }
+
+      let(:service_config) {
+        YAML.load_file(File.expand_path('spec/docker-compose/fixtures/compose_env_vars.yaml'))
+      }
+
+      it 'should substitute env var placeholders for real values' do
+        parsed = ComposeUtils.parse_env_variables(service_config)
+
+        parsed_as_string = parsed.to_s
+
+        expected.each {|e| expect(parsed_as_string).to include e }
+      end
+    end
+
+    context 'Compose File Contains Env Vars' do
+      before(:each) {
+        @compose = DockerCompose.load(File.expand_path('spec/docker-compose/fixtures/compose_env_vars.yaml'))
+      }
+
+      after(:each) do
+        @compose.delete
+      end
+
+      it 'should read a YAML file correctly' do
+        expect(@compose.containers.length).to eq(2)
+      end
+
+      context 'All containers' do
+        it 'should start/stop all containers' do
+          # Start containers to test Stop
+          @compose.start
+          @compose.containers.values.each do |container|
+            expect(container.running?).to be true
+          end
+
+          # Stop containers
+          @compose.stop
+          @compose.containers.values.each do |container|
+            expect(container.running?).to be false
+          end
+        end
+
+        it 'should start/kill all containers' do
+          # Start containers to test Kill
+          @compose.start
+          @compose.containers.values.each do |container|
+            expect(container.running?).to be true
+          end
+
+          # Kill containers
+          @compose.kill
+          @compose.containers.values.each do |container|
+            expect(container.running?).to be false
+          end
+        end
+
+        it 'should start/delete all containers' do
+          # Start containers to test Delete
+          @compose.start
+          @compose.containers.values.each do |container|
+            expect(container.running?).to be true
+          end
+
+          # Delete containers
+          @compose.delete
+          expect(@compose.containers.empty?).to be true
+        end
+      end
+
+    end
+
+  end
+end

--- a/spec/docker-compose/fixtures/Dockerfile-rspec
+++ b/spec/docker-compose/fixtures/Dockerfile-rspec
@@ -1,0 +1,2 @@
+FROM busybox
+CMD ["ls", "/tmp"]

--- a/spec/docker-compose/fixtures/compose_env_vars.yaml
+++ b/spec/docker-compose/fixtures/compose_env_vars.yaml
@@ -1,0 +1,29 @@
+busyboxenv1:
+  image: busybox
+  container_name: busybox-container
+  ports:
+    - ${DOCKER_PORT_1}
+    - "8000:8000"
+    - "127.0.0.1:8001:8001"
+  expose:
+    - "5000"
+  links:
+    - busyboxenv2
+  command: ping busybox2
+  environment:
+    - MYENV1=${DOCKER_MYENV1_VALUE}
+  volumes:
+    - ${DOCKER_HOST_DATA_DIR}:/data
+  labels:
+    - com.example.foo=bar
+
+busyboxenv2:
+  image: ${DOCKER_IMAGE}
+  expose:
+    - "6000"
+  command: ping localhost
+  environment:
+    MYENV2: variable2
+  labels:
+    com.example.foo: bar
+  command: ping ${DOCKER_PING_TARGET}


### PR DESCRIPTION
Hi @mauricioklein

This PR adds support for a couple of features

1) A named dockerfile in a compose file, for example
```
test-rest-server:
  build: .
  dockerfile: Dockerfile-test-rest
```

2) Specifying environment variables in a compose file. 

The yaml is parsed after loading, replacing any found tags which match the compose env variables format ('${name}'), with real values taken from ENV

This is first PR I've raised for someone else's open source project so I hope the level of detail ok

Thanks
tom

