### PR TITLE
Fix numeric ports

### DIFF
--- a/lib/docker-compose/utils/compose_utils.rb
+++ b/lib/docker-compose/utils/compose_utils.rb
@@ -64,7 +64,7 @@ module ComposeUtils
     host_port = nil
     host_ip = nil
 
-    port_parts = port_entry.split(':')
+    port_parts = port_entry.to_s.split(':')
 
     case port_parts.length
       # [container port]

--- a/spec/docker-compose/utils/compose_utils_spec.rb
+++ b/spec/docker-compose/utils/compose_utils_spec.rb
@@ -37,6 +37,13 @@ describe ComposeUtils do
       expect(compose_port.host_ip).to eq(nil)
     end
 
+    it 'should be able to use numeric ports too in pattern "[container port]"' do
+      compose_port = ComposeUtils.format_port(8080)
+      expect(compose_port.container_port).to eq('8080')
+      expect(compose_port.host_port).to eq(nil)
+      expect(compose_port.host_ip).to eq(nil)
+    end
+
     it 'should recognize pattern "[host port]:[container port]"' do
       compose_port = ComposeUtils.format_port('8080:7777')
       expect(compose_port.container_port).to eq('7777')


### PR DESCRIPTION
Without this fix I had errors like:
```ruby
NoMethodError:
  undefined method `split' for 8000:Integer
```
and docker-compose.yml which contained ports like:
```
    ports:
      - 8000
```